### PR TITLE
Disable the Manage Cloud edit controls when there are no clouds created ...

### DIFF
--- a/src/IronFoundry.Ui.Controls/Converters/IsNullConverter.cs
+++ b/src/IronFoundry.Ui.Controls/Converters/IsNullConverter.cs
@@ -1,0 +1,29 @@
+﻿namespace IronFoundry.Ui.Controls.Converters
+{
+    using System;
+    using System.Globalization;
+    using System.Windows.Data;
+    
+    public class IsNullConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (value == null)
+            {
+                return false;
+            }
+
+            if (!(value is bool))
+            {
+                return true;
+            }
+
+            return value;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            return value;
+        }
+    }
+}

--- a/src/IronFoundry.Ui.Controls/IronFoundry.Ui.Controls.csproj
+++ b/src/IronFoundry.Ui.Controls/IronFoundry.Ui.Controls.csproj
@@ -87,6 +87,7 @@
       <Link>Utilities\ExtensionMethods.cs</Link>
     </Compile>
     <Compile Include="Converters\CsvConverter.cs" />
+    <Compile Include="Converters\IsNullConverter.cs" />
     <Compile Include="Converters\TitleCaseConverter.cs" />
     <Compile Include="Model\CloudEventArgs.cs" />
     <Compile Include="Model\CloudFoundryProvider.cs" />

--- a/src/IronFoundry.Ui.Controls/Resources/Resources.xaml
+++ b/src/IronFoundry.Ui.Controls/Resources/Resources.xaml
@@ -166,6 +166,7 @@
   <converters:MinutesConverter x:Key="minutesConverter" />
   <converters:CsvConverter x:Key="csvConverter" />
   <converters:TitleCaseConverter x:Key="titleCaseConverter" />
+  <converters:IsNullConverter x:Key="isNullConverter" />
   <BooleanToVisibilityConverter x:Key="booleanToVisibilityConverter" />
 
 </ResourceDictionary>

--- a/src/IronFoundry.Ui.Controls/Views/ManageClouds.xaml
+++ b/src/IronFoundry.Ui.Controls/Views/ManageClouds.xaml
@@ -69,59 +69,60 @@
                    SelectedItem="{Binding SelectedCloud, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
         </DockPanel>
         <DockPanel Grid.Column="1" HorizontalAlignment="Stretch">
-          <Grid Margin="10">
-            <Grid.ColumnDefinitions>
-              <ColumnDefinition Width="Auto" />
-              <ColumnDefinition Width="*" />
-            </Grid.ColumnDefinitions>
+          <StackPanel>
+              <Grid Margin="10" IsEnabled="{Binding SelectedCloud, Mode=OneWay, Converter={StaticResource isNullConverter}}">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition Width="*" />
+                </Grid.ColumnDefinitions>
 
-            <Grid.RowDefinitions>
-              <RowDefinition Height="Auto" />
-              <RowDefinition Height="Auto" />
-              <RowDefinition Height="Auto" />
-              <RowDefinition Height="Auto" />
-              <RowDefinition Height="Auto" />
-              <RowDefinition Height="Auto" />
-              <RowDefinition Height="Auto" />
-              <RowDefinition Height="Auto" />
-              <RowDefinition Height="Auto" />
-            </Grid.RowDefinitions>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="Auto" />
+                </Grid.RowDefinitions>
 
-            <Label Grid.Row="0" Grid.ColumnSpan="2" Content="Specify cloud settings." />
+                <Label Grid.Row="0" Grid.ColumnSpan="2" Content="Specify cloud settings." />
 
-            <Label Grid.Row="1" Grid.Column="0" Content="Server Name:" Foreground="{StaticResource DarkBlueBrushKey}" VerticalAlignment="Center" />
-            <TextBox Grid.Row="1" Grid.Column="1" x:Name="ServerNameTextBox"
-                     Text="{Binding Path=SelectedCloud.ServerName, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" VerticalAlignment="Center" />
+                <Label Grid.Row="1" Grid.Column="0" Content="Server Name:" Foreground="{StaticResource DarkBlueBrushKey}" VerticalAlignment="Center" />
+                <TextBox Grid.Row="1" Grid.Column="1" x:Name="ServerNameTextBox"
+                    Text="{Binding Path=SelectedCloud.ServerName, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" VerticalAlignment="Center" />
 
-            <Label Grid.Row="2" Grid.Column="0" Content="URL:" Foreground="{StaticResource DarkBlueBrushKey}" VerticalAlignment="Center" />
-            <TextBox Grid.Row="2" Grid.Column="2"
-                     Text="{Binding Path=SelectedCloud.ServerUrl, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" VerticalAlignment="Center" />
+                <Label Grid.Row="2" Grid.Column="0" Content="URL:" Foreground="{StaticResource DarkBlueBrushKey}" VerticalAlignment="Center" />
+                <TextBox Grid.Row="2" Grid.Column="2"
+                    Text="{Binding Path=SelectedCloud.ServerUrl, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" VerticalAlignment="Center" />
 
-            <Label Grid.Row="3" Grid.ColumnSpan="2" Content="Credentials" />
+                <Label Grid.Row="3" Grid.ColumnSpan="2" Content="Credentials" />
 
-            <Label Grid.Row="4" Grid.Column="0" Content="Email:" Foreground="{StaticResource DarkBlueBrushKey}" VerticalAlignment="Center" />
-            <TextBox Grid.Row="4" Grid.Column="1"
-                     Text="{Binding Path=SelectedCloud.Email, Mode=TwoWay, UpdateSourceTrigger=Default}" VerticalAlignment="Center" Name="txtEmail" />
+                <Label Grid.Row="4" Grid.Column="0" Content="Email:" Foreground="{StaticResource DarkBlueBrushKey}" VerticalAlignment="Center" />
+                <TextBox Grid.Row="4" Grid.Column="1"
+                    Text="{Binding Path=SelectedCloud.Email, Mode=TwoWay, UpdateSourceTrigger=Default}" VerticalAlignment="Center" Name="txtEmail" />
 
-            <Label Grid.Row="5" Grid.Column="0" Content="Password:" Foreground="{StaticResource DarkBlueBrushKey}" VerticalAlignment="Center" />
-            <PasswordBox Grid.Row="5" Grid.Column="1" u:PasswordHelper.Attach="True"
-                         u:PasswordHelper.Password="{Binding Path=SelectedCloud.Password,Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}" VerticalAlignment="Center" />
+                <Label Grid.Row="5" Grid.Column="0" Content="Password:" Foreground="{StaticResource DarkBlueBrushKey}" VerticalAlignment="Center" />
+                <PasswordBox Grid.Row="5" Grid.Column="1" u:PasswordHelper.Attach="True"
+                        u:PasswordHelper.Password="{Binding Path=SelectedCloud.Password,Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}" VerticalAlignment="Center" />
+              </Grid>
 
-            <StackPanel Grid.Row="6" Grid.ColumnSpan="2" Orientation="Horizontal">
-              <Button Content="Validate Account" Margin="4" Command="{Binding ValidateAccountCommand}" />
-              <Label Content="Account Valid." Margin="4"
-                     Visibility="{Binding Path=IsSelectedCloudAccountValid,Mode=OneWay,Converter={StaticResource booleanToVisibilityConverter}}" />
+              <StackPanel Margin="10">
+                <StackPanel Orientation="Horizontal">
+                    <Button Content="Validate Account" Margin="4" Command="{Binding ValidateAccountCommand}" />
+                    <Label Content="Account Valid." Margin="4"
+                    Visibility="{Binding Path=IsSelectedCloudAccountValid,Mode=OneWay,Converter={StaticResource booleanToVisibilityConverter}}" />
+                </StackPanel>
+
+                <StackPanel Orientation="Horizontal">
+                    <Button Content="Register Account" Margin="4" Command="{Binding RegisterAccountCommand}" />
+                    <Label Content="Account Registered." Margin="4"
+                    Visibility="{Binding Path=IsSelectedCloudAccountRegistered,Mode=OneWay,Converter={StaticResource booleanToVisibilityConverter}}" />
+                </StackPanel>
+
+                <uc:ucSpinnerApple Margin="2" HorizontalAlignment="Left"
+                            Visibility="{Binding Path=IsBusy,Mode=OneWay,Converter={StaticResource booleanToVisibilityConverter}}" />
             </StackPanel>
-            
-            <StackPanel Grid.Row="7" Grid.ColumnSpan="2" Orientation="Horizontal">
-              <Button Content="Register Account" Margin="4" Command="{Binding RegisterAccountCommand}" />
-              <Label Content="Account Registered." Margin="4"
-                     Visibility="{Binding Path=IsSelectedCloudAccountRegistered,Mode=OneWay,Converter={StaticResource booleanToVisibilityConverter}}" />
-            </StackPanel>
-            
-            <uc:ucSpinnerApple Grid.Row="8" Margin="2" HorizontalAlignment="Left"
-                               Visibility="{Binding Path=IsBusy,Mode=OneWay,Converter={StaticResource booleanToVisibilityConverter}}" />
-          </Grid>
+          </StackPanel>
         </DockPanel>
       </Grid>
     </Border>


### PR DESCRIPTION
...or selected.  It was confusing as a first-time user to enter cloud config information into the edit controls and discover afterward that I needed to click the Add button first.
